### PR TITLE
Removed duplicate ExecStart entry

### DIFF
--- a/systemd/ratools-rad.service
+++ b/systemd/ratools-rad.service
@@ -10,7 +10,6 @@ Restart=on-failure
 StandardOutput=syslog
 StandardError=syslog
 Sockets=ratools-rad.socket
-ExecStart=/bin/sh -c '[ -f /etc/ratools/rad.conf ] && /usr/bin/ractl < /etc/ratools/rad.conf'
 
 [Install]
 Also=ratools-rad.socket


### PR DESCRIPTION
Double ExecStart lines are only allowed for OneShot service files. systemd refuses to start it.
Using it on Fedora 22